### PR TITLE
Bump version: 1.2.4 → 1.2.5

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,7 +2,7 @@
 History
 =======
 
-1.2.4 (2021-05-06)
+1.2.5 (2021-05-06)
 ------------------
 
 * Now all the attributes of the LexItem objects are immutable for consistency.

--- a/README.rst
+++ b/README.rst
@@ -54,42 +54,41 @@ Each lexical item is represented in a LexItem having the following LexEntryType:
         Type information about all the lexical attributes in a LexItem object.
 
         """
-        ortho = str
-        phon = str
-        lemme = str
-        cgram = str
-        genre = str
-        nombre = str
-        freqlemfilms2 = float
-        freqlemlivres = float
-        freqfilms2 = float
-        freqlivres = float
-        infover = str
-        nbhomogr = int
-        nbhomoph = int
-        islem = bool
-        nblettres = int
-        nbphons = int
-        cvcv = str
-        p_cvcv = str
-        voisorth = int
-        voisphon = int
-        puorth = int
-        puphon = int
-        syll = str
-        nbsyll = int
-        cv_cv = str
-        orthrenv = str
-        phonrenv = str
-        orthosyll = str
-        cgramortho = str
-        deflem = float
-        defobs = int
-        old20 = float
-        pld20 = float
-        morphoder = str
-        nbmorph = int
-        id = int
+        ortho: str
+        phon: str
+        lemme: str
+        cgram: str
+        genre: str
+        nombre: str
+        freqlemfilms2: float
+        freqlemlivres: float
+        freqfilms2: float
+        freqlivres: float
+        infover: str
+        nbhomogr: int
+        nbhomoph: int
+        islem: bool
+        nblettres: int
+        nbphons: int
+        cvcv: str
+        p_cvcv: str
+        voisorth: int
+        voisphon: int
+        puorth: int
+        puphon: int
+        syll: str
+        nbsyll: int
+        cv_cv: str
+        orthrenv: str
+        phonrenv: str
+        orthosyll: str
+        cgramortho: str
+        deflem: float
+        defobs: int
+        old20: float
+        pld20: float
+        morphoder: str
+        nbmorph: int
 
 The meanings of the attributes of this object are as follow:
 

--- a/pylexique/__init__.py
+++ b/pylexique/__init__.py
@@ -4,7 +4,7 @@
 
 __author__ = """SekouDiaoNlp"""
 __email__ = 'diao.sekou.nlp@gmail.com'
-__version__ = '1.2.4'
+__version__ = '1.2.5'
 __copyright__ = "Copyright (c) 2021, SekouDiaoNlp"
 __credits__ = ("Lexique383",)
 __license__ = "MIT"

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.2.4
+current_version = 1.2.5
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -64,6 +64,6 @@ setup(
     test_suite='tests',
     tests_require=test_requirements,
     url='https://github.com/SekouDiaoNlp/pylexique',
-    version='1.2.4',
+    version='1.2.5',
     zip_safe=False,
 )


### PR DESCRIPTION
* Now all the attributes of the LexItem objects are immutable for consistency.
* Added new method Lexique383.get_all_forms(word) to get all the lexical variations of a word.
* This new method returns a list of LexItems having the same root lemma.
* Expanded sample usage of the software in the docs.
* Updated dependencies.